### PR TITLE
Fix plugin module loading.

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -41,7 +41,7 @@ router.post("/invoke/:plugin/:func", async (ctx) => {
   let host = plugins.get(name);
   if (!host) {
     host = new PluginHost();
-    await host.load(`${Deno.cwd()}/${name}/mod.ts`);
+    await host.load(`file://${Deno.cwd()}/${name}/mod.ts`);
     plugins.set(name, host);
   }
 


### PR DESCRIPTION
Use file protocol explicitly, so that it doesn't try to use https when the host
module itself is loaded remotely.
