### PR TITLE
Enrich the host load/invoke protocol.

### DIFF
--- a/host/host.ts
+++ b/host/host.ts
@@ -43,7 +43,7 @@ export class PluginHost {
               result.value = e.data.value;
             }
             if ("error" in e.data) {
-              result.error = e.data.error
+              result.error = e.data.error;
             }
             p.resolve(result);
             this.#invoked.delete(e.data.cid);

--- a/host/host_test.ts
+++ b/host/host_test.ts
@@ -5,6 +5,6 @@ Deno.test("invoke success", async () => {
   const host = new PluginHost();
   await host.load("./testdata/simple_plugin.ts");
   const result = await host.invoke("fn", { name: "test" });
-  assertEquals(result, { message: "name: test" });
+  assertEquals(result, { value: { message: "name: test" } });
   host.close();
 });

--- a/host/mod.ts
+++ b/host/mod.ts
@@ -1,1 +1,2 @@
 export * from "./host.ts";
+export * from "./result.ts";

--- a/host/result.ts
+++ b/host/result.ts
@@ -1,0 +1,39 @@
+/** The result of loading a plugin. */
+export interface LoadResult {
+  /** Whether the load succeeded. */
+  success: boolean;
+
+  /** Exported function names. */
+  functionNames: string[];
+
+  /** The error encountered, if any. */
+  error?: ErrorDetails;
+}
+
+/** The result of a function invocation. */
+export interface InvokeResult {
+  /** The return value of the invocation. */
+  value?: unknown;
+
+  /** The error encountered, if any. */
+  error?: ErrorDetails;
+}
+
+/**
+ * A serializable error object.
+ * 
+ * @remarks
+ * Used as a plain object, not an actual Error. Instances of the Error class lose data when passed
+ * through a worker boundary (even though they're said to support structured cloning) and don't
+ * support conversion to JSON.
+ */
+export interface ErrorDetails {
+  /** The error name. */
+  name: string;
+
+  /** The error message. */
+  message: string;
+
+  /** The error call stack. */
+  stack?: string;
+}

--- a/server/response.ts
+++ b/server/response.ts
@@ -1,3 +1,7 @@
+import { ErrorDetails } from "../host/result.ts";
+
+export type { ErrorDetails };
+
 /** Response to a /status request. */
 export interface StatusResponse {
   /** The plugin module. */
@@ -18,6 +22,9 @@ export interface StatusResponse {
 
   /** The plugin load error, if any. */
   error?: ErrorDetails;
+
+  /** The available function names, if loading succeeded. */
+  functionNames: string[];
 }
 
 /** Maps server status strings to HTTP status codes. */
@@ -67,19 +74,3 @@ export const INVOKE_STATUS = {
   "RuntimeError": 500,
   "InternalError": 500,
 } as const;
-
-/**
- * Information about an error.
- * 
- * Currently equivalent to the Error interface, but expected to be a plain serializable object.
- */
-export interface ErrorDetails {
-  /** The error name. */
-  name: string;
-
-  /** The error message. */
-  message: string;
-
-  /** The error call stack. */
-  stack?: string;
-}


### PR DESCRIPTION
In order to capture logs (an upcoming change), the host will need to
return a full object from invoke, not just the return value. Add a
wrapper type for the invoke result.

Use this as an opportunity to make some other improvements:
- Harmonize the types used by host, worker, and server.
- Simplify error management; as we generally need to pass errors between
serialization boundaries, prefer to use plain JS objects over Error
instances, and direct passing rather than catching and rethrowing.
- Expose (and check) the list of loaded function names.
