### PR TITLE
Upgrade oak to v7.5.0.

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -4,7 +4,7 @@ import {
   RouteParams,
   Router,
   RouterContext,
-} from "https://deno.land/x/oak@v7.3.0/mod.ts";
+} from "https://deno.land/x/oak@v7.5.0/mod.ts";
 import { PluginHost } from "../host/mod.ts";
 import {
   ErrorDetails,


### PR DESCRIPTION
Fixes an issue when running with the latest deno/typescript.
