### PR TITLE
Disable concurrent invocations.

### DIFF
--- a/host/host_test.ts
+++ b/host/host_test.ts
@@ -29,21 +29,25 @@ Deno.test("worker > invoke async", async () => {
   host.terminate();
 });
 
-Deno.test("worker > invoke concurrent", async () => {
-  const host = new PluginHost();
-  await host.load("./testdata/test_plugin.ts");
+Deno.test({
+  name: "worker > invoke concurrent",
+  ignore: true, // reverted to serial; logging at least needs more work
+  fn: async () => {
+    const host = new PluginHost();
+    await host.load("./testdata/test_plugin.ts");
 
-  const first = host.invoke("concur", null);
-  const second = host.invoke("concur", "done");
-  assertEquals(await first, {
-    value: "done",
-    logs: [],
-  });
-  assertEquals(await second, {
-    value: "done",
-    logs: [],
-  });
-  host.terminate();
+    const first = host.invoke("concur", null);
+    const second = host.invoke("concur", "done");
+    assertEquals(await first, {
+      value: "done",
+      logs: [],
+    });
+    assertEquals(await second, {
+      value: "done",
+      logs: [],
+    });
+    host.terminate();
+  },
 });
 
 Deno.test("worker > terminate", async () => {

--- a/host/worker.ts
+++ b/host/worker.ts
@@ -81,7 +81,8 @@ self.onmessage = async (e: MessageEvent<PluginMessage>) => {
       return;
     }
     case "invoke": {
-      invoke(e.data).then((result) => self.postMessage(result));
+      const result = await invoke(e.data);
+      self.postMessage(result);
       return;
     }
   }


### PR DESCRIPTION
This broke logging, which works by capturing all calls made for the span
of a single invoke call. There's a deeper philosophical question to
answer about whether it's worth supporting concurrency within a worker at
all, compared to just creating multiple workers (which we likely want to
do anyway for resiliency). For the initial use cases though, we don't
expect it to matter, so just serialize.