### PR TITLE
Fix typechecking in worker.

### DIFF
--- a/host/host.ts
+++ b/host/host.ts
@@ -1,7 +1,11 @@
 import { Deferred, deferred } from "https://deno.land/std@0.95.0/async/mod.ts";
 import { v4 as uuidV4 } from "https://deno.land/std@0.95.0/uuid/mod.ts";
 import { InvokeResult, LoadResult } from "./result.ts";
-import { InvokeMessage, LoadMessage, PluginResultMessage } from "./worker_api.ts";
+import {
+  InvokeMessage,
+  LoadMessage,
+  PluginResultMessage,
+} from "./worker_api.ts";
 
 /** Hosts a plugin instance. */
 export class PluginHost {

--- a/host/host.ts
+++ b/host/host.ts
@@ -1,7 +1,7 @@
 import { Deferred, deferred } from "https://deno.land/std@0.95.0/async/mod.ts";
 import { v4 as uuidV4 } from "https://deno.land/std@0.95.0/uuid/mod.ts";
 import { InvokeResult, LoadResult } from "./result.ts";
-import { InvokeMessage, LoadMessage, PluginResultMessage } from "./worker.ts";
+import { InvokeMessage, LoadMessage, PluginResultMessage } from "./worker_api.ts";
 
 /** Hosts a plugin instance. */
 export class PluginHost {

--- a/host/worker_api.ts
+++ b/host/worker_api.ts
@@ -1,0 +1,60 @@
+import { InvokeResult, LoadResult } from "./result.ts";
+
+/** A message used to communicate with the worker. */
+export type PluginMessage = LoadMessage | InvokeMessage;
+
+/** The result of of a `PluginMessage` operation. */
+export type PluginResultMessage = LoadResultMessage | InvokeResultMessage;
+
+/**
+ * A request to load a plugin module into the worker.
+ *
+ * A plugin must be loaded before any plugin functions are invoked, and a plugin must only be
+ * loaded once. The result will be posted as a `LoadResult`.
+ */
+export interface LoadMessage {
+  /** Specifies the kind of the message. */
+  kind: "load";
+
+  /** The path of the module to load. */
+  module: string;
+}
+
+/**
+ * The result of loading a plugin.
+ */
+export interface LoadResultMessage extends LoadResult {
+  /** Specifies the kind of the message. */
+  kind: "load";
+}
+
+/**
+ * A request to invoke a plugin function.
+ *
+ * A plugin must be loaded before any plugin functions are invoked; otherwise an error will be
+ * returned. The result will be posted as an `InvokeResultMessage`.
+ */
+export interface InvokeMessage {
+  /** Specifies the kind of the message. */
+  kind: "invoke";
+
+  /** A correlation id, used to identify the corresponding `InvokeResult`. */
+  cid: string;
+
+  /** The path of the module to load. */
+  function: string;
+
+  /** The argument to pass to the function. */
+  argument: unknown;
+}
+
+/**
+ * The result of invoking a plugin function.
+ */
+export interface InvokeResultMessage extends InvokeResult {
+  /** Specifies the kind of the message. */
+  kind: "invoke";
+
+  /** The correlation id passed in with the `InvokeMessage`. */
+  cid: string;
+}

--- a/host/worker_log.ts
+++ b/host/worker_log.ts
@@ -1,3 +1,6 @@
+/// <reference no-default-lib="true" />
+/// <reference lib="deno.worker" />
+
 import { LevelName, setup } from "https://deno.land/std@0.95.0/log/mod.ts";
 import { LogRecord as BaseLogRecord } from "https://deno.land/std@0.95.0/log/logger.ts";
 import {


### PR DESCRIPTION
Previously, the right way to indicate that a module should be checked as
a web worker was not clearly documented. Now it is:
  https://deno.land/manual@v1.11.2/typescript/types

This breaks if types are imported from the worker module though, so
split the exported types to a separate worker_api module.
