### PR TITLE
Enable fetch within plugin functions.

### DIFF
--- a/host/testdata/test_plugin.ts
+++ b/host/testdata/test_plugin.ts
@@ -38,3 +38,46 @@ export async function leakAsync() {
   delay(1).then(() => leakCounter++); // should never finish
   return leakCounter;
 }
+
+export async function doFetch(url: string) {
+  // fetch(string)
+  const strResponse = await fetch(`${url}?string`);
+  let strResult = strResponse.statusText;
+  if (strResponse.ok) {
+    strResult = await strResponse.json();
+  }
+
+  // fetch(URL)
+  const urlResponse = await fetch(new URL(`${url}?url`));
+  let urlResult = urlResponse.statusText;
+  if (urlResponse.ok) {
+    urlResult = await urlResponse.json();
+  }
+
+  // fetch(Request)
+  const reqResponse = await fetch(new Request(url, { method: "CUSTOM" }));
+  let reqResult = reqResponse.statusText;
+  if (reqResponse.ok) {
+    reqResult = await reqResponse.json();
+  }
+
+  return [strResult, urlResult, reqResult];
+}
+
+export async function fetchAbort(arg: { url: string; abort: boolean }) {
+  const ctl = new AbortController();
+  if (arg.abort) {
+    ctl.abort();
+  }
+  const res = await fetch(new Request(arg.url, { signal: ctl.signal }));
+  return await res.json();
+}
+
+let leakResult = "No value.";
+export function doFetchLeak(url?: string) {
+  if (url) {
+    // not awaited, should be aborted upon return
+    fetch(url).then((r) => leakResult = r.statusText);
+  }
+  return leakResult;
+}


### PR DESCRIPTION
This adds fetch to the list of allowed functions, with a wrapper that
aborts the request if it lasts beyond the scope of the invocation. This
wrapper can also be used to apply custom headers for the proxy to use,
which we'll almost certainly want to do.