### PR TITLE
Fix plugin configuration definition.

### DIFF
--- a/host/plugin.ts
+++ b/host/plugin.ts
@@ -3,8 +3,11 @@ export interface Plugin {
   /** The plugin module import path. */
   module: string;
 
-  /** The plugin identifier, if configured. */
-  id?: string;
+  /** The plugin identifier, if available. */
+  $id?: string;
+
+  /** The account identifier, if available. */
+  accountId?: string;
 
   /** Additional global values to set for plugin invocations. */
   globals?: Record<string, unknown>;


### PR DESCRIPTION
These values aren't used yet, so it doesn't really matter, but for the
future align the names with the keys in the actual configuration.