### PR TITLE
Create a pool of concurrent plugin workers.

### DIFF
--- a/host/host.ts
+++ b/host/host.ts
@@ -1,76 +1,83 @@
-import { Deferred, deferred } from "https://deno.land/std@0.95.0/async/mod.ts";
+import {
+  Deferred,
+  deferred,
+  delay,
+} from "https://deno.land/std@0.95.0/async/mod.ts";
 import { v4 as uuidV4 } from "https://deno.land/std@0.95.0/uuid/mod.ts";
 import { Plugin } from "./plugin.ts";
-import { InvokeResult, LoadResult } from "./result.ts";
-import {
-  InvokeMessage,
-  LoadMessage,
-  PluginResultMessage,
-} from "./worker_api.ts";
+import { ErrorDetails, InvokeResult, LoadResult } from "./result.ts";
+import { LoadMessage, PluginResultMessage } from "./worker_api.ts";
+
+// Delay for the worker reload loop.
+const RELOAD_DELAY_MS = 30_000;
+
+// Number of workers that can fail to load before we stop trying.
+const MAX_LOAD_FAILURES = 3;
 
 /** Hosts a plugin instance. */
 export class PluginHost {
   #plugin: Plugin;
-  #worker: Worker;
-  #loaded: Deferred<LoadResult>;
+  #loadSuccess?: LoadResult;
+  #loadFailure?: LoadResult;
+
+  // State:
+  //  #state starts as 'loading'
+  //  After any worker is loaded, #state becomes 'ready' and #started completes
+  //  If MAX_LOAD_FAILURES workers fail to load in a row, #state becomes 'failed'
+  //    If #started hasn't completed yet, it's rejected
+  //  On shutdown(), #state becomes 'closing'
+  //  On terminate() (directly or in shutdown), #state becomes 'closed' and #shutdown completes
+  #state: PluginHostStatus["state"];
+  #started: Deferred<void>;
+  #shutdown: Deferred<void>;
+
+  // Worker Pool:
+  //  #workers contains all workers (up to the plugin's concurrency limit)
+  //  #idle contains those which are loaded and ready to serve the next invoke request
+  //  #waiters contains invocations waiting for a worker to be ready
+  //  When a load or invoke finishes, the worker is provided to #waiters if any, else #idle
+  //  When a load fails or invoke is aborted, the worker is shut down and #reload is signaled
+  //  See #maintainPool for the load/reload details
+  #workers: Set<Worker>;
+  #idle: Worker[];
+  #waiters: Deferred<Worker>[];
+  #reload: Deferred<void>;
+
+  #invocations = 0;
   #invoked: Map<string, Deferred<InvokeResult>>;
-  #state: "initial" | "active" | "closing" | "closed";
 
   constructor(plugin: Plugin) {
     this.#plugin = plugin;
-    this.#worker = new Worker(new URL("./worker.ts", import.meta.url), {
-      "type": "module",
-    });
-
-    this.#loaded = deferred<LoadResult>();
+    this.#state = "loading";
+    this.#workers = new Set();
+    this.#idle = [];
+    this.#waiters = [];
     this.#invoked = new Map();
-    this.#state = "initial";
+    this.#started = deferred();
+    this.#shutdown = deferred();
+    this.#reload = deferred();
+    this.#maintainPool();
+  }
 
-    this.#worker.onmessage = (e: MessageEvent<PluginResultMessage>) => {
-      switch (e.data.kind) {
-        case "load": {
-          const result: LoadResult = {
-            success: e.data.success,
-            functionNames: e.data.functionNames,
-          };
-          if ("error" in e.data) {
-            result.error = e.data.error;
-          }
-          this.#loaded.resolve(result);
-          return;
-        }
-        case "invoke": {
-          const result: InvokeResult = {
-            value: e.data.value,
-            logs: e.data.logs,
-          };
-          if ("error" in e.data) {
-            result.error = e.data.error;
-          }
-          this.#completeInvoke(e.data.cid, result);
-          return;
-        }
-      }
+  /** The current status of the host. */
+  get status(): PluginHostStatus {
+    return {
+      state: this.#state,
+      workers: this.#workers.size,
+      idle: this.#idle.length,
+      invocations: this.#invocations,
+      functionNames: this.#loadSuccess?.functionNames ?? [],
+      loadError: this.#loadFailure?.error,
     };
   }
 
-  /**
-   * Loads the plugin module.
-   *
-   * @returns The load result
-   */
-  async load(): Promise<LoadResult> {
-    if (this.#state !== "initial") {
-      throw new Error("invalid host state");
-    }
-    this.#state = "active";
-    const msg: LoadMessage = { kind: "load", plugin: this.#plugin };
-    this.#worker.postMessage(msg);
-    return await this.#loaded;
+  /** Returns a promise that completes when initial plugin loading is done. */
+  async ensureLoaded() {
+    await this.#started;
   }
 
   /**
-   * Invokes the loaded plugin.
+   * Invokes a plugin function.
    *
    * @param func The function name
    * @param argument The argument
@@ -82,12 +89,14 @@ export class PluginHost {
     argument: unknown,
     opts?: InvokeOptions,
   ): Promise<InvokeResult> {
-    if (this.#state !== "active") {
+    if (this.#state !== "ready") {
       throw new Error("invalid host state");
     }
+
     const cid = uuidV4.generate();
-    const res = deferred<InvokeResult>();
-    this.#invoked.set(cid, res);
+    const result = deferred<InvokeResult>();
+    this.#invoked.set(cid, result);
+    this.#invocations++;
 
     opts?.signal?.addEventListener("abort", () => {
       this.#completeInvoke(cid, {
@@ -98,14 +107,27 @@ export class PluginHost {
       });
     });
 
-    const msg: InvokeMessage = {
+    const worker = await this.#nextWorker(opts?.signal);
+    if (!worker) {
+      return await result; // should be completed as aborted
+    }
+
+    worker.postMessage({
       kind: "invoke",
       cid: cid,
       function: func,
       argument: argument,
-    };
-    this.#worker.postMessage(msg);
-    return await res;
+    });
+
+    const value = await result;
+
+    if (opts?.signal?.aborted) {
+      this.#workerFailed(worker);
+    } else {
+      this.#workerReady(worker);
+    }
+
+    return value;
   }
 
   /** Resolves an invocation promise and removes it from the in-progress map. */
@@ -150,8 +172,144 @@ export class PluginHost {
         });
       }
       this.#invoked.clear();
-      this.#worker.terminate();
+      for (const worker of this.#workers) {
+        worker.terminate();
+      }
+      this.#shutdown.resolve();
     }
+  }
+
+  /** Starts the worker pool and refills it as needed. */
+  async #maintainPool() {
+    const size = Math.max(1, this.#plugin.concurrency ?? 0);
+
+    const running = () => this.#state === "loading" || this.#state === "ready";
+    let failureCount = 0;
+
+    do {
+      while (this.#workers.size < size) {
+        const [worker, result] = await this.#createWorker();
+
+        // shutdown may have happened while loading; just discard the worker if so
+        if (!running()) {
+          worker.terminate();
+          break;
+        }
+
+        if (result.success) {
+          failureCount = 0;
+          this.#workers.add(worker);
+          this.#workerReady(worker);
+          if (this.#state === "loading") {
+            this.#state = "ready";
+            this.#started.resolve();
+          }
+        } else {
+          this.#workerFailed(worker);
+          failureCount++;
+          if (failureCount >= MAX_LOAD_FAILURES) {
+            switch (this.#state) {
+              case "loading":
+                this.#started.reject(new Error("loading failed"));
+                // fallthrough
+              case "ready":
+                this.#state = "failed";
+            }
+          }
+        }
+      }
+
+      await Promise.race([this.#shutdown, this.#reload]);
+      if (running()) {
+        // reset the reload trigger
+        this.#reload = deferred();
+
+        // if all workers are down, reload immediately; else wait a bit
+        if (this.#workers.size) {
+          await delay(RELOAD_DELAY_MS);
+        }
+      }
+    } while (running());
+  }
+
+  /**
+   * Creates a new worker and loads a plugin into it.
+   *
+   * @returns The worker and its load result
+   */
+  async #createWorker(): Promise<[Worker, LoadResult]> {
+    const loaded = deferred<LoadResult>();
+    const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+      "type": "module",
+    });
+
+    worker.onmessage = (e: MessageEvent<PluginResultMessage>) => {
+      switch (e.data.kind) {
+        case "load": {
+          const result: LoadResult = {
+            success: e.data.success,
+            functionNames: e.data.functionNames,
+          };
+          if ("error" in e.data) {
+            result.error = e.data.error;
+          }
+          loaded.resolve(result);
+          return;
+        }
+        case "invoke": {
+          const result: InvokeResult = {
+            value: e.data.value,
+            logs: e.data.logs,
+          };
+          if ("error" in e.data) {
+            result.error = e.data.error;
+          }
+          this.#completeInvoke(e.data.cid, result);
+          return;
+        }
+      }
+    };
+
+    const msg: LoadMessage = { kind: "load", plugin: this.#plugin };
+    worker.postMessage(msg);
+
+    const result = await loaded;
+    return [worker, result];
+  }
+
+  /** Returns the next available worker, or nothing if aboorted. */
+  #nextWorker(signal?: AbortSignal | null): Promise<Worker | void> {
+    const worker = this.#idle.shift();
+    if (worker) {
+      return Promise.resolve(worker);
+    }
+
+    const available = deferred<Worker>();
+    this.#waiters.push(available);
+
+    const abandoned = deferred<void>();
+    signal?.addEventListener("abort", () => {
+      abandoned.resolve();
+      available.then((w) => this.#workerReady(w));
+    });
+    return Promise.race([available, abandoned]);
+  }
+
+  /** Provides a worker to the next waiter, or adds it to the idle list. */
+  #workerReady(worker: Worker) {
+    const waiting = this.#waiters.shift();
+    if (waiting) {
+      waiting.resolve(worker);
+    } else {
+      this.#idle.push(worker);
+    }
+  }
+
+  /** Cleans up a failed worker. */
+  #workerFailed(worker: Worker) {
+    worker.terminate();
+    this.#workers.delete(worker);
+    this.#reload.resolve();
   }
 }
 
@@ -159,4 +317,33 @@ export class PluginHost {
 export interface InvokeOptions {
   /** An signal that can cancel the invocation. */
   signal?: AbortSignal | null;
+}
+
+/** Describes loading state and some metrics for a plugin host. */
+export interface PluginHostStatus {
+  /**
+   * The overall host state.
+   *
+   * `loading`: Performing the initial plugin load
+   * `ready`: At least one worker is loaded and ready
+   * `failed`: All workers have failed and will not be restarted
+   * `closing`: Shutdown has begun
+   * `closed`: All workers have terminated
+   */
+  state: "loading" | "ready" | "failed" | "closing" | "closed";
+
+  /** The current worker pool size. */
+  workers: number;
+
+  /** The number of idle workers. */
+  idle: number;
+
+  /** The number of invocations processed. */
+  invocations: number;
+
+  /** The loaded function names, if available. */
+  functionNames: string[];
+
+  /** The most recent load error, if any. */
+  loadError?: ErrorDetails;
 }

--- a/host/host.ts
+++ b/host/host.ts
@@ -10,12 +10,14 @@ import {
 
 /** Hosts a plugin instance. */
 export class PluginHost {
+  #plugin: Plugin;
   #worker: Worker;
   #loaded: Deferred<LoadResult>;
   #invoked: Map<string, Deferred<InvokeResult>>;
   #state: "initial" | "active" | "closing" | "closed";
 
-  constructor() {
+  constructor(plugin: Plugin) {
+    this.#plugin = plugin;
     this.#worker = new Worker(new URL("./worker.ts", import.meta.url), {
       "type": "module",
     });
@@ -55,15 +57,14 @@ export class PluginHost {
   /**
    * Loads the plugin module.
    *
-   * @param plugin The plugin definition
    * @returns The load result
    */
-  async load(plugin: Plugin): Promise<LoadResult> {
+  async load(): Promise<LoadResult> {
     if (this.#state !== "initial") {
       throw new Error("invalid host state");
     }
     this.#state = "active";
-    const msg: LoadMessage = { kind: "load", plugin };
+    const msg: LoadMessage = { kind: "load", plugin: this.#plugin };
     this.#worker.postMessage(msg);
     return await this.#loaded;
   }

--- a/host/host_test.ts
+++ b/host/host_test.ts
@@ -4,10 +4,11 @@ import {
 } from "https://deno.land/std@0.95.0/testing/asserts.ts";
 import { serve } from "https://deno.land/std@0.95.0/http/server.ts";
 import { PluginHost } from "./host.ts";
+import { delay } from "https://deno.land/std@0.95.0/async/mod.ts";
 
 Deno.test("worker > invoke success", async () => {
   const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.load();
+  await host.ensureLoaded();
   const result = await host.invoke("fn", { name: "test" });
   assertEquals(result.value, { message: "name: test" });
   assertEquals(result.logs, [
@@ -19,7 +20,7 @@ Deno.test("worker > invoke success", async () => {
 
 Deno.test("worker > invoke async", async () => {
   const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.load();
+  await host.ensureLoaded();
   const result = await host.invoke("afn", "str");
 
   assertEquals(result.value, "afn: str");
@@ -28,7 +29,7 @@ Deno.test("worker > invoke async", async () => {
 
 Deno.test("worker > terminate", async () => {
   const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.load();
+  await host.ensureLoaded();
   const invoke = host.invoke("spin", null);
   host.terminate();
   const result = await invoke;
@@ -41,7 +42,7 @@ Deno.test("worker > terminate", async () => {
 
 Deno.test("worker > shutdown", async () => {
   const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.load();
+  await host.ensureLoaded();
   const invoke = host.invoke("wait", 50);
   const shutdown = host.shutdown();
   await assertThrowsAsync(() => host.invoke("wait", 50)); // closed to new requests
@@ -53,7 +54,7 @@ Deno.test("worker > shutdown", async () => {
 
 Deno.test("worker > abort", async () => {
   const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.load();
+  await host.ensureLoaded();
 
   const ctl = new AbortController();
   const invoke = host.invoke("spin", null, { signal: ctl.signal });
@@ -70,7 +71,7 @@ Deno.test("worker > abort", async () => {
 
 Deno.test("worker > restricted", async () => {
   const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.load();
+  await host.ensureLoaded();
 
   const result = await host.invoke("doEval", "1");
   assertEquals(result.value, undefined);
@@ -80,7 +81,7 @@ Deno.test("worker > restricted", async () => {
 
 Deno.test("worker > wrap schedule", async () => {
   const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.load();
+  await host.ensureLoaded();
 
   const result1 = await host.invoke("leakAsync", "{}");
   assertEquals(result1.value, 0);
@@ -92,7 +93,7 @@ Deno.test("worker > wrap schedule", async () => {
 
 Deno.test("worker > wrap fetch", async () => {
   const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.load();
+  await host.ensureLoaded();
 
   const srv = serve({ port: 0 });
   const port = (srv.listener.addr as Deno.NetAddr).port;
@@ -135,8 +136,7 @@ Deno.test("worker > global", async () => {
     module: "./testdata/test_plugin.ts",
     globals: { "MY_KEY": 12345 },
   });
-
-  await host.load();
+  await host.ensureLoaded();
 
   const result = await host.invoke("useGlobal", "test");
   assertEquals(result.value, "test: 12345");
@@ -144,47 +144,57 @@ Deno.test("worker > global", async () => {
   host.terminate();
 });
 
-Deno.test({
-  name: "worker > concurrent",
-  ignore: true, // TODO: WIP
-  fn: async () => {
-    const host = new PluginHost({
-      module: "./testdata/test_plugin.ts",
-      concurrency: 2,
-    });
-    await host.load();
+Deno.test("worker > concurrent", async () => {
+  const host = new PluginHost({
+    module: "./testdata/test_plugin.ts",
+    concurrency: 2,
+  });
 
-    // double-check that the two are loaded in different workers
-    const first = host.invoke("concur", null);
-    const second = host.invoke("concur", null);
-    assertEquals((await first).value, 1);
-    assertEquals((await second).value, 1);
-    host.terminate();
-  },
+  // wait for 2 workers; ensureLoaded() only waits for 1
+  let loadTime = 0;
+  while (loadTime < 30_000 && host.status.workers < 2) {
+    await delay(100);
+    loadTime += 100;
+  }
+  assertEquals(host.status.workers, 2);
+
+  // double-check that the two are loaded in different workers
+  const one = host.invoke("concur", null);
+  const two = host.invoke("concur", null);
+  assertEquals((await one).value, 1);
+  assertEquals((await two).value, 1);
+
+  // schedule a few more; they should cycle between workers
+  const three = host.invoke("concur", null);
+  const four = host.invoke("concur", null);
+  const five = host.invoke("concur", null);
+  const six = host.invoke("concur", null);
+  assertEquals((await three).value, 2);
+  assertEquals((await four).value, 2);
+  assertEquals((await five).value, 3);
+  assertEquals((await six).value, 3);
+
+  host.terminate();
 });
 
-Deno.test({
-  name: "worker > reload",
-  ignore: true, // TODO: WIP
-  fn: async () => {
-    const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-    await host.load();
+Deno.test("worker > reload", async () => {
+  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
+  await host.ensureLoaded();
 
-    const ctl = new AbortController();
-    const first = host.invoke("spin", null, { signal: ctl.signal });
-    const second = host.invoke("afn", "x");
+  const ctl = new AbortController();
+  const first = host.invoke("spin", null, { signal: ctl.signal });
+  const second = host.invoke("afn", "x");
 
-    // first should be aborted, but second should still complete
-    ctl.abort();
-    const result1 = await first;
-    assertEquals(result1.value, undefined);
-    assertEquals(result1.error, {
-      name: "AbortError",
-      message: "Invocation was aborted",
-    });
-    const result2 = await second;
-    assertEquals(result2.value, "afn: x");
+  // first should be aborted, but second should still complete
+  ctl.abort();
+  const result1 = await first;
+  assertEquals(result1.value, undefined);
+  assertEquals(result1.error, {
+    name: "AbortError",
+    message: "Invocation was aborted",
+  });
+  const result2 = await second;
+  assertEquals(result2.value, "afn: x");
 
-    host.terminate();
-  },
+  host.terminate();
 });

--- a/host/host_test.ts
+++ b/host/host_test.ts
@@ -2,9 +2,9 @@ import {
   assertEquals,
   assertThrowsAsync,
 } from "https://deno.land/std@0.95.0/testing/asserts.ts";
+import { delay } from "https://deno.land/std@0.95.0/async/mod.ts";
 import { serve } from "https://deno.land/std@0.95.0/http/server.ts";
 import { PluginHost } from "./host.ts";
-import { delay } from "https://deno.land/std@0.95.0/async/mod.ts";
 
 Deno.test("worker > invoke success", async () => {
   const host = new PluginHost({ module: "./testdata/test_plugin.ts" });

--- a/host/host_test.ts
+++ b/host/host_test.ts
@@ -6,8 +6,8 @@ import { serve } from "https://deno.land/std@0.95.0/http/server.ts";
 import { PluginHost } from "./host.ts";
 
 Deno.test("worker > invoke success", async () => {
-  const host = new PluginHost();
-  await host.load({ module: "./testdata/test_plugin.ts" });
+  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
+  await host.load();
   const result = await host.invoke("fn", { name: "test" });
   assertEquals(result.value, { message: "name: test" });
   assertEquals(result.logs, [
@@ -18,8 +18,8 @@ Deno.test("worker > invoke success", async () => {
 });
 
 Deno.test("worker > invoke async", async () => {
-  const host = new PluginHost();
-  await host.load({ module: "./testdata/test_plugin.ts" });
+  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
+  await host.load();
   const result = await host.invoke("afn", "str");
 
   assertEquals(result.value, "afn: str");
@@ -30,8 +30,8 @@ Deno.test({
   name: "worker > invoke concurrent",
   ignore: true, // reverted to serial; logging at least needs more work
   fn: async () => {
-    const host = new PluginHost();
-    await host.load({ module: "./testdata/test_plugin.ts" });
+    const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
+    await host.load();
 
     const first = host.invoke("concur", null);
     const second = host.invoke("concur", "done");
@@ -42,8 +42,8 @@ Deno.test({
 });
 
 Deno.test("worker > terminate", async () => {
-  const host = new PluginHost();
-  await host.load({ module: "./testdata/test_plugin.ts" });
+  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
+  await host.load();
   const invoke = host.invoke("spin", null);
   host.terminate();
   const result = await invoke;
@@ -55,8 +55,8 @@ Deno.test("worker > terminate", async () => {
 });
 
 Deno.test("worker > shutdown", async () => {
-  const host = new PluginHost();
-  await host.load({ module: "./testdata/test_plugin.ts" });
+  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
+  await host.load();
   const invoke = host.invoke("wait", 50);
   const shutdown = host.shutdown();
   await assertThrowsAsync(() => host.invoke("wait", 50)); // closed to new requests
@@ -67,8 +67,8 @@ Deno.test("worker > shutdown", async () => {
 });
 
 Deno.test("worker > abort", async () => {
-  const host = new PluginHost();
-  await host.load({ module: "./testdata/test_plugin.ts" });
+  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
+  await host.load();
 
   const ctl = new AbortController();
   const invoke = host.invoke("spin", null, { signal: ctl.signal });
@@ -84,8 +84,8 @@ Deno.test("worker > abort", async () => {
 });
 
 Deno.test("worker > restricted", async () => {
-  const host = new PluginHost();
-  await host.load({ module: "./testdata/test_plugin.ts" });
+  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
+  await host.load();
 
   const result = await host.invoke("doEval", "1");
   assertEquals(result.value, undefined);
@@ -94,8 +94,8 @@ Deno.test("worker > restricted", async () => {
 });
 
 Deno.test("worker > wrap schedule", async () => {
-  const host = new PluginHost();
-  await host.load({ module: "./testdata/test_plugin.ts" });
+  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
+  await host.load();
 
   const result1 = await host.invoke("leakAsync", "{}");
   assertEquals(result1.value, 0);
@@ -106,8 +106,8 @@ Deno.test("worker > wrap schedule", async () => {
 });
 
 Deno.test("worker > wrap fetch", async () => {
-  const host = new PluginHost();
-  await host.load({ module: "./testdata/test_plugin.ts" });
+  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
+  await host.load();
 
   const srv = serve({ port: 0 });
   const port = (srv.listener.addr as Deno.NetAddr).port;
@@ -146,12 +146,12 @@ Deno.test("worker > wrap fetch", async () => {
 });
 
 Deno.test("worker > global", async () => {
-  const host = new PluginHost();
-
-  await host.load({
+  const host = new PluginHost({
     module: "./testdata/test_plugin.ts",
     globals: { "MY_KEY": 12345 },
   });
+
+  await host.load();
 
   const result = await host.invoke("useGlobal", "test");
   assertEquals(result.value, "test: 12345");

--- a/host/plugin.ts
+++ b/host/plugin.ts
@@ -11,4 +11,7 @@ export interface Plugin {
 
   /** Additional global values to set for plugin invocations. */
   globals?: Record<string, unknown>;
+
+  /** The number of concurrent workers to create. */
+  concurrency?: number;
 }

--- a/host/testdata/test_plugin.ts
+++ b/host/testdata/test_plugin.ts
@@ -1,4 +1,4 @@
-import { deferred, delay } from "https://deno.land/std@0.95.0/async/mod.ts";
+import { delay } from "https://deno.land/std@0.95.0/async/mod.ts";
 import * as log from "https://deno.land/std@0.95.0/log/mod.ts";
 
 export function fn(arg: { name: string }): { message: string } {
@@ -9,14 +9,6 @@ export function fn(arg: { name: string }): { message: string } {
 
 export async function afn(s: string) {
   return await Promise.resolve(`afn: ${s}`);
-}
-
-const concurDone = deferred<string>();
-export async function concur(val: string | null) {
-  if (val) {
-    concurDone.resolve(val);
-  }
-  return await concurDone;
 }
 
 export function spin() {
@@ -85,4 +77,11 @@ export function doFetchLeak(url?: string) {
 declare const MY_KEY: number;
 export function useGlobal(arg: string) {
   return `${arg}: ${MY_KEY}`;
+}
+
+let concurCalls = 0;
+export async function concur() {
+  concurCalls++;
+  await delay(50);
+  return concurCalls;
 }

--- a/host/worker.ts
+++ b/host/worker.ts
@@ -10,7 +10,10 @@ import {
   LoadResultMessage,
   PluginMessage,
 } from "./worker_api.ts";
-import { openInvocationContext, closeInvocationContext } from "./worker_context.ts";
+import {
+  closeInvocationContext,
+  openInvocationContext,
+} from "./worker_context.ts";
 import { logBuffer } from "./worker_log.ts";
 
 // The loaded plugin module.

--- a/host/worker_context.ts
+++ b/host/worker_context.ts
@@ -15,10 +15,10 @@ let current: InvocationContext | null = null;
 
 /**
  * Initializes a restricted global environment for an invocation.
- * 
+ *
  * The context should be closed with `closeInvocationContext` when the current plugin call is
  * finished to clean up resources, and _must_ be closed before the next call to this function.
- * 
+ *
  * @param cid The call id
  * @param globals Additional values to add to the global environment
  */

--- a/host/worker_context.ts
+++ b/host/worker_context.ts
@@ -11,8 +11,37 @@ type Override<K, T> = (
   prop: PropertyDescriptor,
 ) => PropertyDescriptor;
 
+let current: InvocationContext | null = null;
+
+/**
+ * Initializes a restricted global environment for an invocation.
+ * 
+ * The context should be closed with `closeInvocationContext` when the current plugin call is
+ * finished to clean up resources, and _must_ be closed before the next call to this function.
+ * 
+ * @param cid The call id
+ * @param globals Additional values to add to the global environment
+ */
+export function openInvocationContext(
+  cid: string,
+  globals?: Record<string, unknown>,
+) {
+  const ctx = new InvocationContext(cid, globals);
+  ctx.set(); // will throw if previous was not closed, no need to check current
+  current = ctx;
+}
+
+/**
+ * Cleans up any current invocation global execution environment (created with
+ * `openInvocationContext`) and restores global values to their defaults.
+ */
+export function closeInvocationContext() {
+  current?.restore();
+  current = null;
+}
+
 /** Creates a restricted execution environment for a plugin invocation. */
-export class InvocationContext {
+class InvocationContext {
   #cid: string;
   #customGlobals: Record<string, unknown>;
   #orig: Record<PropertyKey, PropertyDescriptor>;
@@ -34,7 +63,7 @@ export class InvocationContext {
   }
 
   /** Sets the global environment to the isolated invocation context. */
-  enter() {
+  set() {
     const env = Object(globalThis);
     if (env[cid]) {
       throw new Error(
@@ -64,7 +93,7 @@ export class InvocationContext {
   }
 
   /** Restores the global environment. */
-  exit() {
+  restore() {
     const env = Object(globalThis);
     if (env[cid] !== this.#cid) {
       throw new Error(

--- a/server/server.ts
+++ b/server/server.ts
@@ -78,9 +78,9 @@ export class Server {
   }
 
   /** Stops the HTTP server. */
-  stop() {
+  async stop() {
     this.#abort.abort();
-    this.#host.terminate();
+    await this.#host.shutdown();
   }
 
   /** GET /status */

--- a/server/server.ts
+++ b/server/server.ts
@@ -54,7 +54,7 @@ export class Server {
   constructor(plugin: Plugin, port: number = 8080) {
     this.#plugin = plugin;
     this.#port = port;
-    this.#host = new PluginHost();
+    this.#host = new PluginHost(plugin);
     this.#running = false;
     this.#status = { module: plugin.module, status: "Loading" };
     this.#abort = new AbortController();
@@ -94,7 +94,7 @@ export class Server {
 
   /** Loads the plugin module. */
   async #load() {
-    const result = await this.#host.load(this.#plugin);
+    const result = await this.#host.load();
     this.#updateLoadStatus(result);
     this.#loaded.resolve();
   }
@@ -105,9 +105,9 @@ export class Server {
       return;
     }
 
-    this.#nextHost = new PluginHost();
+    this.#nextHost = new PluginHost(this.#plugin);
     (async () => {
-      const result = await this.#nextHost!.load(this.#plugin);
+      const result = await this.#nextHost!.load();
       this.#updateLoadStatus(result);
       this.#host = this.#nextHost!;
       this.#nextHost = undefined;

--- a/server/server_test.ts
+++ b/server/server_test.ts
@@ -91,7 +91,7 @@ function invokeTest(
       await Timeout.race([srv.ensureLoaded()], 5000);
       await Timeout.race([fn(host, srv)], 5000);
     } finally {
-      srv.stop();
+      await Timeout.race([srv.stop()], 5000);
       await Timeout.race([stopped], 5000);
     }
   });


### PR DESCRIPTION
First, add a `concurrency` field to plugin configuration, which will match an upcoming change to the resource format.

In `PluginHost`, maintain a pool of `concurrency` workers and dispatch invocations to them one at a time. Handle load failures and aborted invocations (i.e., timeouts) by terminating the worker and restarting it.

The server type had the beginnings of a multi-host approach; this is no longer needed, so remove it in favor of pooling at the worker level.

This trickiest part of this design is how to track the overall lifecycle of the host to reflect potentially many workers. The choices here are fairly arbitrary: a plugin is "loaded" when one worker is ready, and is considered permanently failed if three loads fail in a row.

Finally, refactor `InvocationContext`; the previous `enter`/`exit` API suggested (and was originally intended as) swapping in and out of different call contexts as concurrent calls in the same worker suspended and resumed. Hooking into every suspend and resume would be difficult, and with the new worker pool we don't plan to do so. Therefore, make the global environment API reflect that it's more of a one-shot create-then-close operation.