### PR TITLE
Record fetch metadata for invocations.

### DIFF
--- a/host/host.ts
+++ b/host/host.ts
@@ -138,6 +138,7 @@ export class PluginHost {
       const r: InvokeResult = {
         value: result.value ?? undefined,
         logs: result.logs ?? [],
+        fetches: result.fetches ?? [],
       };
       if (result.error) {
         r.error = result.error;
@@ -274,6 +275,7 @@ export class PluginHost {
           const result: InvokeResult = {
             value: e.data.value,
             logs: e.data.logs,
+            fetches: e.data.fetches,
           };
           if ("error" in e.data) {
             result.error = e.data.error;

--- a/host/host_test.ts
+++ b/host/host_test.ts
@@ -238,7 +238,8 @@ function assertFetch(
   actual: FetchRecord | undefined,
   expected: Partial<FetchRecord>,
 ) {
-  const [minDuration, maxDuration] = [1, 50];
+  // CI can be slow, so be permissive even though these should be ~instant.
+  const [minDuration, maxDuration] = [1, 5000];
   assertExists(actual);
   assertObjectMatch(actual!, expected);
 

--- a/host/host_test.ts
+++ b/host/host_test.ts
@@ -1,9 +1,9 @@
 import {
   assert,
   assertEquals,
+  assertExists,
   assertObjectMatch,
   assertThrowsAsync,
-  assertExists,
 } from "https://deno.land/std@0.95.0/testing/asserts.ts";
 import { delay } from "https://deno.land/std@0.95.0/async/mod.ts";
 import { serve } from "https://deno.land/std@0.95.0/http/server.ts";

--- a/host/host_test.ts
+++ b/host/host_test.ts
@@ -8,32 +8,26 @@ import {
 import { delay } from "https://deno.land/std@0.95.0/async/mod.ts";
 import { serve } from "https://deno.land/std@0.95.0/http/server.ts";
 import { PluginHost } from "./host.ts";
+import { Plugin } from "./plugin.ts";
 import { FetchRecord } from "./result.ts";
 
-Deno.test("worker > invoke success", async () => {
-  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.ensureLoaded();
+hostTest("worker > invoke success", {}, async (host) => {
   const result = await host.invoke("fn", { name: "test" });
   assertEquals(result.value, { message: "name: test" });
   assertEquals(result.logs, [
     { level: "INFO", loggerName: "default", "message": "called fn" },
     { level: "DEBUG", loggerName: "default", "message": `{"name":"test"}` },
   ]);
-  await host.shutdown();
 });
 
-Deno.test("worker > invoke async", async () => {
-  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.ensureLoaded();
+hostTest("worker > invoke async", {}, async (host) => {
   const result = await host.invoke("afn", "str");
-
   assertEquals(result.value, "afn: str");
-  await host.shutdown();
 });
 
-Deno.test("worker > terminate", async () => {
-  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.ensureLoaded();
+hostTest("worker > terminate", {}, async (host, ctl) => {
+  ctl.shutdown = false;
+
   const invoke = host.invoke("spin", null);
   host.terminate();
   const result = await invoke;
@@ -44,9 +38,9 @@ Deno.test("worker > terminate", async () => {
   });
 });
 
-Deno.test("worker > shutdown", async () => {
-  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.ensureLoaded();
+hostTest("worker > shutdown", {}, async (host, ctl) => {
+  ctl.shutdown = false;
+
   const invoke = host.invoke("wait", 50);
   const shutdown = host.shutdown();
   await assertThrowsAsync(() => host.invoke("wait", 50)); // closed to new requests
@@ -56,10 +50,7 @@ Deno.test("worker > shutdown", async () => {
   assertEquals(result.value, 50);
 });
 
-Deno.test("worker > abort", async () => {
-  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.ensureLoaded();
-
+hostTest("worker > abort", {}, async (host) => {
   const ctl = new AbortController();
   const invoke = host.invoke("spin", null, { signal: ctl.signal });
   ctl.abort();
@@ -70,35 +61,23 @@ Deno.test("worker > abort", async () => {
     name: "AbortError",
     message: "Invocation was aborted",
   });
-  await host.shutdown();
 });
 
-Deno.test("worker > restricted", async () => {
-  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.ensureLoaded();
-
+hostTest("worker > restricted", {}, async (host) => {
   const result = await host.invoke("doEval", "1");
   assertEquals(result.value, undefined);
   assertEquals(result.error?.message, "eval is not supported");
-  await host.shutdown();
 });
 
-Deno.test("worker > wrap schedule", async () => {
-  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.ensureLoaded();
-
+hostTest("worker > wrap schedule", {}, async (host) => {
   const result1 = await host.invoke("leakAsync", "{}");
   assertEquals(result1.value, 0);
 
   const result2 = await host.invoke("leakAsync", "{}");
   assertEquals(result2.value, 0);
-  await host.shutdown();
 });
 
-Deno.test("worker > wrap fetch", async () => {
-  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.ensureLoaded();
-
+hostTest("worker > wrap fetch", {}, async (host, ctl) => {
   const srv = serve({ port: 0 });
   const port = (srv.listener.addr as Deno.NetAddr).port;
   (async () => {
@@ -106,6 +85,7 @@ Deno.test("worker > wrap fetch", async () => {
       req.respond({ body: `"${req.method} ${req.url}"` });
     }
   })();
+  ctl.after(() => srv.close());
 
   const url = `http://localhost:${port}/test`;
 
@@ -157,30 +137,14 @@ Deno.test("worker > wrap fetch", async () => {
   assertEquals(result4.value, "No value.");
   const result5 = await host.invoke("doFetchLeak", undefined);
   assertEquals(result5.value, "Request aborted.");
-
-  srv.close();
-  await host.shutdown();
 });
 
-Deno.test("worker > global", async () => {
-  const host = new PluginHost({
-    module: "./testdata/test_plugin.ts",
-    globals: { "MY_KEY": 12345 },
-  });
-  await host.ensureLoaded();
-
+hostTest("worker > global", { globals: { "MY_KEY": 12345 } }, async (host) => {
   const result = await host.invoke("useGlobal", "test");
   assertEquals(result.value, "test: 12345");
-
-  await host.shutdown();
 });
 
-Deno.test("worker > concurrent", async () => {
-  const host = new PluginHost({
-    module: "./testdata/test_plugin.ts",
-    concurrency: 2,
-  });
-
+hostTest("worker > concurrent", { concurrency: 2 }, async (host) => {
   // wait for 2 workers; ensureLoaded() only waits for 1
   let loadTime = 0;
   while (loadTime < 30_000 && host.status.workers < 2) {
@@ -204,14 +168,9 @@ Deno.test("worker > concurrent", async () => {
   assertEquals((await four).value, 2);
   assertEquals((await five).value, 3);
   assertEquals((await six).value, 3);
-
-  await host.shutdown();
 });
 
-Deno.test("worker > reload", async () => {
-  const host = new PluginHost({ module: "./testdata/test_plugin.ts" });
-  await host.ensureLoaded();
-
+hostTest("worker > reload", {}, async (host) => {
   const ctl = new AbortController();
   const first = host.invoke("spin", null, { signal: ctl.signal });
   const second = host.invoke("afn", "x");
@@ -226,18 +185,54 @@ Deno.test("worker > reload", async () => {
   });
   const result2 = await second;
   assertEquals(result2.value, "afn: x");
-
-  await host.shutdown();
 });
 
-Deno.test("worker > load failure", async () => {
-  const host = new PluginHost({ module: "./testdata/invalid_plugin.ts" });
-  await host.ensureLoaded();
-  assertEquals(host.status.state, "failed");
-  assertEquals(host.status.loadError?.message, "must fail to load");
+hostTest(
+  "worker > load failure",
+  { module: "./testdata/invalid_plugin.ts" },
+  (host) => {
+    assertEquals(host.status.state, "failed");
+    assertEquals(host.status.loadError?.message, "must fail to load");
+  },
+);
 
-  await host.shutdown();
-});
+// Runs a plugin test case, managing the life cycle of the host.
+function hostTest(
+  name: string,
+  def: Partial<Plugin>,
+  fn: (host: PluginHost, ctl: HostTestController) => Promise<void> | void,
+) {
+  Deno.test(name, async () => {
+    const plugin = { module: "./testdata/test_plugin.ts", ...def };
+    const host = new PluginHost(plugin);
+    const after: (() => void | Promise<void>)[] = [];
+    const ctl: HostTestController = {
+      shutdown: true,
+      after: (fn) => after.push(fn),
+    };
+
+    try {
+      await host.ensureLoaded();
+      await fn(host, ctl);
+    } finally {
+      if (ctl.shutdown) {
+        await host.shutdown();
+      }
+      for (const fn of after) {
+        await fn();
+      }
+    }
+  });
+}
+
+// Provides additional control over a plugin test case.
+interface HostTestController {
+  // Whether or not to automatically shut down the host (true by default).
+  shutdown: boolean;
+
+  // Actions to run after the test.
+  after(fn: () => void | Promise<void>): void;
+}
 
 function assertFetch(
   actual: FetchRecord | undefined,

--- a/host/result.ts
+++ b/host/result.ts
@@ -20,6 +20,9 @@ export interface InvokeResult {
 
   /** Any messages logged during the invocation. */
   logs: LogRecord[];
+
+  /** Metadata about fetches performed. */
+  fetches: FetchRecord[];
 }
 
 /**
@@ -51,4 +54,34 @@ export interface LogRecord {
 
   /** The message. */
   message: string;
+}
+
+/** Metadata about a fetch performed during an invocation. */
+export interface FetchRecord {
+  /** The request scheme. */
+  scheme: string;
+
+  /** The remote host. */
+  host: string;
+
+  /** The HTTP method. */
+  method: string;
+
+  /** The response status code. */
+  status: number;
+
+  /** The response status text. */
+  statusText: string;
+
+  /** The time at which the request was made. */
+  startTime: string;
+
+  /** The time at which the response was received. */
+  endTime: string;
+
+  /** Sent body size. */
+  sentBytes: number;
+
+  /** Received body size. */
+  receivedBytes: number;
 }

--- a/host/result.ts
+++ b/host/result.ts
@@ -76,7 +76,7 @@ export interface FetchRecord {
   /** The time at which the request was made. */
   startTime: string;
 
-  /** The time at which the response was received. */
+  /** The time at which the response was received (and its body read). */
   endTime: string;
 
   /** Sent body size. */

--- a/host/testdata/test_plugin.ts
+++ b/host/testdata/test_plugin.ts
@@ -46,8 +46,13 @@ export async function doFetch(url: string) {
     urlResult = await urlResponse.json();
   }
 
-  // fetch(Request)
-  const reqResponse = await fetch(new Request(url, { method: "CUSTOM" }));
+  // fetch(Request) + Body
+  const reqResponse = await fetch(
+    new Request(url, {
+      body: `${url} body`,
+      method: "CUSTOM",
+    }),
+  );
   let reqResult = reqResponse.statusText;
   if (reqResponse.ok) {
     reqResult = await reqResponse.json();

--- a/host/worker.ts
+++ b/host/worker.ts
@@ -48,7 +48,7 @@ async function load(msg: LoadMessage): Promise<LoadResultMessage> {
   }
 
   try {
-    openInvocationContext("load", msg.plugin.globals);
+    openInvocationContext("", msg.plugin.globals);
     module = await import(msg.plugin.module);
     plugin = msg.plugin;
     result.success = true;
@@ -71,6 +71,7 @@ async function invoke(msg: InvokeMessage): Promise<InvokeResultMessage> {
     cid: msg.cid,
     value: undefined,
     logs: [],
+    fetches: [],
   };
 
   if (!plugin) {
@@ -85,7 +86,9 @@ async function invoke(msg: InvokeMessage): Promise<InvokeResultMessage> {
   }
 
   try {
-    openInvocationContext(msg.cid, plugin.globals);
+    openInvocationContext(msg.cid, plugin.globals, {
+      fetch: (rec) => result.fetches.push(rec),
+    });
     result.value = await Promise.resolve(fn(msg.argument));
   } catch (e) {
     result.error = createError(e);

--- a/host/worker_context.ts
+++ b/host/worker_context.ts
@@ -45,7 +45,13 @@ export function closeInvocationContext() {
 
 /** Logs global events that occur during an invocation. */
 export interface Logger {
-  /** Called when a  */
+  /**
+   * Called when a `fetch` has been performed and the response's body has been
+   * fully read.
+   * 
+   * If a response body is never read, the fetch will be logged when the call
+   * is finalized via `closeInvocationContext`.
+   */
   fetch?: (rec: FetchRecord) => void;
 }
 

--- a/host/worker_context.ts
+++ b/host/worker_context.ts
@@ -149,9 +149,9 @@ class InvocationContext {
 
     const record = this.#newFetchRecord(input);
 
-    // Call fetch with a customized (re-)initializer:
-    // - A signal that aborts when the invocation is done.
-    // - A custom invocation id header.
+    // Call fetch with a customized (re-)initializer including:
+    // - A signal that aborts when the invocation is done
+    // - A custom invocation id header
     // - A body that logs its size
     let p = fn(input, {
       signal: joinSignals(input.signal, this.#abort.signal),

--- a/host/worker_context.ts
+++ b/host/worker_context.ts
@@ -48,7 +48,7 @@ export interface Logger {
   /**
    * Called when a `fetch` has been performed and the response's body has been
    * fully read.
-   * 
+   *
    * If a response body is never read, the fetch will be logged when the call
    * is finalized via `closeInvocationContext`.
    */

--- a/server/response.ts
+++ b/server/response.ts
@@ -1,6 +1,6 @@
-import { ErrorDetails, LogRecord } from "../host/result.ts";
+import { ErrorDetails, FetchRecord, LogRecord } from "../host/result.ts";
 
-export type { ErrorDetails, LogRecord };
+export type { ErrorDetails, FetchRecord, LogRecord };
 
 /** Response to a /status request. */
 export interface StatusResponse {
@@ -75,6 +75,9 @@ export interface InvokeResponse {
 
   /** Any messages logged during the invocation. */
   logs: LogRecord[];
+
+  /** Records of fetches performed during the invocation. */
+  fetches: FetchRecord[];
 }
 
 /** Maps invoke status strings to HTTP status codes. */

--- a/server/server.ts
+++ b/server/server.ts
@@ -113,6 +113,7 @@ export class Server {
       status: "OK",
       result: undefined,
       logs: [],
+      fetches: [],
     };
     ctx.response.body = body;
 
@@ -173,6 +174,7 @@ export class Server {
       const result = await call;
       body.result = result.value;
       body.logs = result.logs;
+      body.fetches = result.fetches;
       if (result.error) {
         fail("RuntimeError", result.error);
       }


### PR DESCRIPTION
Log roughly the same metadata as is currently available to the proxy,
except:
- Individual requests (with timing, size, and status) for https
- Some differences around counting request and response size

Also add a custom header with a call correlation id.

Open questions:
- Is the complex size counting worth it? Is there a better way?
- Do we want to try to account for header size?
- The current logging probably gets compressed size, whereas this gets
the full size; which is right?
- Do we want to collect any additional metadata? Do we even want to
record this much about https?
- Is setting the end timestamp to when the body is read right, or would
it be more consistent set it when the response is first received?
