### PR TITLE
Accept invocation id as a caller header.

### DIFF
--- a/host/worker.ts
+++ b/host/worker.ts
@@ -68,7 +68,7 @@ async function load(msg: LoadMessage): Promise<LoadResultMessage> {
 async function invoke(msg: InvokeMessage): Promise<InvokeResultMessage> {
   const result: InvokeResultMessage = {
     kind: "invoke",
-    cid: msg.cid,
+    token: msg.token,
     value: undefined,
     logs: [],
     fetches: [],
@@ -86,7 +86,7 @@ async function invoke(msg: InvokeMessage): Promise<InvokeResultMessage> {
   }
 
   try {
-    openInvocationContext(msg.cid, plugin.globals, {
+    openInvocationContext(msg.invocationId, plugin.globals, {
       fetch: (rec) => result.fetches.push(rec),
     });
     result.value = await Promise.resolve(fn(msg.argument));

--- a/host/worker_api.ts
+++ b/host/worker_api.ts
@@ -42,7 +42,7 @@ export interface InvokeMessage {
   /** An opaque token to be passed back with the corresponding `InvokeResult`. */
   token: string;
 
-  /** A caller-provided idetifier for the invocation. */
+  /** A caller-provided identifier for the invocation. */
   invocationId?: string;
 
   /** The path of the module to load. */

--- a/host/worker_api.ts
+++ b/host/worker_api.ts
@@ -39,8 +39,11 @@ export interface InvokeMessage {
   /** Specifies the kind of the message. */
   kind: "invoke";
 
-  /** A correlation id, used to identify the corresponding `InvokeResult`. */
-  cid: string;
+  /** An opaque token to be passed back with the corresponding `InvokeResult`. */
+  token: string;
+
+  /** A caller-provided idetifier for the invocation. */
+  invocationId?: string;
 
   /** The path of the module to load. */
   function: string;
@@ -56,6 +59,6 @@ export interface InvokeResultMessage extends InvokeResult {
   /** Specifies the kind of the message. */
   kind: "invoke";
 
-  /** The correlation id passed in with the `InvokeMessage`. */
-  cid: string;
+  /** The token passed in with the `InvokeMessage`. */
+  token: string;
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -165,7 +165,10 @@ export class Server {
     // Instead, for the time being respect the custom X-Timeout header.
     const timeout = Number.parseInt(ctx.request.headers.get("X-Timeout") ?? "");
     const ctl = new AbortController();
-    let call = this.#host.invoke(func, arg, { signal: ctl.signal });
+    let call = this.#host.invoke(func, arg, {
+      invocationId: ctx.request.headers.get("Yext-Invocation-ID"),
+      signal: ctl.signal,
+    });
     if (timeout) {
       call = this.#configureTimeout(call, ctl, timeout);
     }

--- a/server/server_test.ts
+++ b/server/server_test.ts
@@ -15,6 +15,7 @@ invokeTest(
     const response = await fetch(`${host}/invoke/up`, {
       method: "POST",
       body: JSON.stringify("str"),
+      headers: { "Yext-Invocation-ID": "custom-invocation-id" },
     });
 
     const body: InvokeResponse = await response.json();


### PR DESCRIPTION
Also draw a distinction between this id and the internal mechanism
used to communicate with the worker. They're both sorts of call
identifiers, but there's no reason to tie them together.
